### PR TITLE
Add vehicle info API endpoint

### DIFF
--- a/app/Http/Controllers/VehicleInfoController.php
+++ b/app/Http/Controllers/VehicleInfoController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\VehicleInfoService;
+use Illuminate\Http\JsonResponse;
+
+class VehicleInfoController extends Controller
+{
+    public function __construct(private VehicleInfoService $service)
+    {
+    }
+
+    /**
+     * Devuelve la información del vehículo en formato JSON.
+     */
+    public function show(string $plate): JsonResponse
+    {
+        $info = $this->service->fetchVehicleInfo($plate);
+
+        return response()->json($info);
+    }
+}

--- a/app/Services/VehicleInfoService.php
+++ b/app/Services/VehicleInfoService.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+
+class VehicleInfoService
+{
+    /**
+     * Obtiene la información de un vehículo desde el sitio externo.
+     */
+    public function fetchVehicleInfo(string $plate): array
+    {
+        $url = 'https://www.ecuadorlegalonline.com/modulo/sri/matriculacion/consultar-vehiculo-rubros.php';
+
+        $response = Http::withHeaders([
+            'Accept' => '*/*',
+            'Accept-Language' => 'es-ES,es;q=0.9,en;q=0.8',
+            'Accept-Encoding' => 'gzip, deflate, br, zstd',
+            'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36',
+            'X-Requested-With' => 'XMLHttpRequest',
+            'Referer' => 'https://www.ecuadorlegalonline.com/consultas/agencia-nacional-de-transito/consultar-a-quien-pertenece-un-vehiculo-por-placa-ant/',
+        ])->get($url, ['placa' => $plate]);
+
+        if ($response->successful()) {
+            return $response->json();
+        }
+
+        throw new \Exception('Error al obtener información del vehículo');
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Http\Controllers\VehicleInfoController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/api/vehicle-info/{plate}', [VehicleInfoController::class, 'show']);


### PR DESCRIPTION
## Summary
- add service for external vehicle info API
- add controller and route to expose the data from backend

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657f416e1c832fbe13b6a5c564bc06