### PR TITLE
Fix CSRF error on login route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,9 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::post('/api/login', [AuthController::class, 'login']);
+Route::post('/api/login', [AuthController::class, 'login'])
+    ->withoutMiddleware([
+        Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
+    ]);
 
 Route::middleware('jwt')->get('/api/vehicle-info/{plate}', [VehicleInfoController::class, 'show']);


### PR DESCRIPTION
## Summary
- disable CSRF protection for `/api/login`

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865b0769108832fb7f8491842f2e2b9