### PR TITLE
Add commercial info API

### DIFF
--- a/app/Http/Controllers/CommercialInfoController.php
+++ b/app/Http/Controllers/CommercialInfoController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+
+class CommercialInfoController extends Controller
+{
+    public function show(): JsonResponse
+    {
+        return response()->json(['message' => 'ok']);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\VehicleInfoController;
 use App\Http\Controllers\ChatGptController;
+use App\Http\Controllers\CommercialInfoController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -17,6 +18,11 @@ Route::post('/api/login', [AuthController::class, 'login'])
 Route::middleware('jwt')->get('/api/vehicle-info/{plate}', [VehicleInfoController::class, 'show']);
 
 Route::post('/api/conexion_chatgpt', [ChatGptController::class, 'handle'])
+    ->withoutMiddleware([
+        Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
+    ]);
+
+Route::get('/api/comercial-info', [CommercialInfoController::class, 'show'])
     ->withoutMiddleware([
         Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
     ]);

--- a/tests/Feature/CommercialInfoTest.php
+++ b/tests/Feature/CommercialInfoTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class CommercialInfoTest extends TestCase
+{
+    public function test_commercial_info_endpoint_returns_ok(): void
+    {
+        $response = $this->get('/api/comercial-info');
+
+        $response->assertStatus(200)
+                 ->assertJson(['message' => 'ok']);
+    }
+}


### PR DESCRIPTION
## Summary
- add `CommercialInfoController` that returns `ok`
- register `/api/comercial-info` route
- add feature test for the new endpoint

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d70a30e0832f8aa88c9ec9d041f4