### PR TITLE
Add opciones_preferencias_salud endpoint

### DIFF
--- a/app/Http/Controllers/PreferenciasSaludController.php
+++ b/app/Http/Controllers/PreferenciasSaludController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+
+class PreferenciasSaludController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $path = base_path('preferencias_salud.json');
+        $data = json_decode(file_get_contents($path), true);
+
+        return response()->json($data);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\AuthController;
 use App\Http\Controllers\VehicleInfoController;
 use App\Http\Controllers\ChatGptController;
 use App\Http\Controllers\CommercialInfoController;
+use App\Http\Controllers\PreferenciasSaludController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -23,6 +24,11 @@ Route::post('/api/conexion_chatgpt', [ChatGptController::class, 'handle'])
     ]);
 
 Route::get('/api/comercial-info', [CommercialInfoController::class, 'show'])
+    ->withoutMiddleware([
+        Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
+    ]);
+
+Route::get('/api/opciones_preferencias_salud', [PreferenciasSaludController::class, 'index'])
     ->withoutMiddleware([
         Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
     ]);

--- a/tests/Feature/PreferenciasSaludTest.php
+++ b/tests/Feature/PreferenciasSaludTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class PreferenciasSaludTest extends TestCase
+{
+    public function test_opciones_preferencias_salud_endpoint_returns_data(): void
+    {
+        $expected = json_decode(file_get_contents(base_path('preferencias_salud.json')), true);
+
+        $response = $this->get('/api/opciones_preferencias_salud');
+
+        $response->assertStatus(200)
+                 ->assertExactJson($expected);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `PreferenciasSaludController` to return preferencias_salud.json
- add `/api/opciones_preferencias_salud` route
- add feature test for the new endpoint

## Testing
- `composer test` *(fails: composer not found)*
- `php artisan test` *(fails: php not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c8277c88c832fae4d43801108fa44