### PR TITLE
Add health quoting endpoint

### DIFF
--- a/app/Http/Controllers/CotizarSaludPorPreferenciasController.php
+++ b/app/Http/Controllers/CotizarSaludPorPreferenciasController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class CotizarSaludPorPreferenciasController extends Controller
+{
+    public function handle(Request $request): JsonResponse
+    {
+        $path = base_path('cotizador_salud.json');
+        $data = json_decode(file_get_contents($path), true);
+
+        return response()->json($data);
+    }
+}

--- a/cotizador_salud.json
+++ b/cotizador_salud.json
@@ -1,0 +1,29 @@
+[
+  {
+    "idProducto": "1",
+    "orden": "1",
+    "nombrePorducto": "Confiplus",
+    "nombreAseguradora": "Confiamed",
+    "valor": "125.54",
+    "urlImagenAseguradora": "http://",
+    "puntuacion": "5"
+  },
+  {
+    "idProducto": "2",
+    "orden": "2",
+    "nombrePorducto": "Saludsa 3G",
+    "nombreAseguradora": "Saludsa",
+    "valor": "146.74",
+    "urlImagenAseguradora": "http://",
+    "puntuacion": "4"
+  },
+  {
+    "idProducto": "3",
+    "orden": "3",
+    "nombrePorducto": "Humana 123",
+    "nombreAseguradora": "Humana",
+    "valor": "176.23",
+    "urlImagenAseguradora": "http://",
+    "puntuacion": "3"
+  }
+]

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\VehicleInfoController;
 use App\Http\Controllers\ChatGptController;
 use App\Http\Controllers\CommercialInfoController;
 use App\Http\Controllers\PreferenciasSaludController;
+use App\Http\Controllers\CotizarSaludPorPreferenciasController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -29,6 +30,11 @@ Route::get('/api/comercial-info', [CommercialInfoController::class, 'show'])
     ]);
 
 Route::get('/api/opciones_preferencias_salud', [PreferenciasSaludController::class, 'index'])
+    ->withoutMiddleware([
+        Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
+    ]);
+
+Route::post('/api/cotizar_salud_por_preferencias', [CotizarSaludPorPreferenciasController::class, 'handle'])
     ->withoutMiddleware([
         Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
     ]);

--- a/tests/Feature/CotizarSaludPorPreferenciasTest.php
+++ b/tests/Feature/CotizarSaludPorPreferenciasTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class CotizarSaludPorPreferenciasTest extends TestCase
+{
+    public function test_cotizar_salud_por_preferencias_endpoint_returns_data(): void
+    {
+        $payload = [
+            'preferencias' => [
+                ['id' => '1', 'orden' => '1'],
+                ['id' => '3', 'orden' => '2'],
+                ['id' => '2', 'orden' => '3'],
+            ],
+            'parametros' => [
+                'edad' => '25',
+                'genero' => 'F',
+            ],
+        ];
+
+        $expected = json_decode(file_get_contents(base_path('cotizador_salud.json')), true);
+
+        $response = $this->postJson('/api/cotizar_salud_por_preferencias', $payload);
+
+        $response->assertStatus(200)
+                 ->assertExactJson($expected);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `CotizarSaludPorPreferenciasController`
- expose `/api/cotizar_salud_por_preferencias` POST endpoint
- store temporary health quotes in `cotizador_salud.json`
- add feature test for the endpoint

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686c8a39930c832faadfb70b82b81c32